### PR TITLE
feat: add model selector

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -21,6 +21,17 @@ def register():
         bpy.utils.register_class(operators.GeneratePointCloudOperator)
         bpy.utils.register_class(panels.DA3Panel)
         bpy.types.Scene.da3_input_folder = bpy.props.StringProperty(subtype='DIR_PATH')
+        bpy.types.Scene.da3_model_name = bpy.props.EnumProperty(
+            items=[
+                ('da3-small', 'DA3 Small', 'Small model for faster inference'),
+                ('da3-base', 'DA3 Base', 'Base model with balanced performance'),
+                ('da3-large', 'DA3 Large', 'Large model for better quality'),
+                ('da3-giant', 'DA3 Giant', 'Giant model for highest quality'),
+            ],
+            name="Model",
+            description="Select DA3 model variant",
+            default='da3-large'
+        )
     else:
         raise ValueError("installation failed.")
 
@@ -31,6 +42,7 @@ def unregister():
         bpy.utils.unregister_class(operators.GeneratePointCloudOperator)
         bpy.utils.unregister_class(panels.DA3Panel)
         del bpy.types.Scene.da3_input_folder
+        del bpy.types.Scene.da3_model_name
 
 if __name__ == "__main__":
     register()

--- a/operators.py
+++ b/operators.py
@@ -7,24 +7,34 @@ from .utils import run_model, import_point_cloud, create_cameras
 
 add_on_path = Path(__file__).parent
 MODELS_DIR = os.path.join(add_on_path, 'models')
-MODEL_PATH = os.path.join(MODELS_DIR, 'model.safetensors')
-_URL = "https://huggingface.co/depth-anything/DA3-LARGE/resolve/main/model.safetensors"
+_URLS = {
+    'da3-small': "https://huggingface.co/depth-anything/DA3-SMALL/resolve/main/model.safetensors",
+    'da3-base': "https://huggingface.co/depth-anything/DA3-BASE/resolve/main/model.safetensors",
+    'da3-large': "https://huggingface.co/depth-anything/DA3-LARGE/resolve/main/model.safetensors",
+    'da3-giant': "https://huggingface.co/depth-anything/DA3-GIANT/resolve/main/model.safetensors",
+}
 model = None
+current_model_name = None
 
-def get_model():
-    global model
-    if model is None:
+def get_model_path(model_name):
+    return os.path.join(MODELS_DIR, f'{model_name}.safetensors')
+
+def get_model(model_name):
+    global model, current_model_name
+    if model is None or current_model_name != model_name:
         from depth_anything_3.api import DepthAnything3
-        model = DepthAnything3()
-        if os.path.exists(MODEL_PATH):
+        model = DepthAnything3(model_name=model_name)
+        model_path = get_model_path(model_name)
+        if os.path.exists(model_path):
             from safetensors.torch import load_file
-            weight = load_file(MODEL_PATH)
+            weight = load_file(model_path)
             model.load_state_dict(weight, strict=False)
         else:
-            raise FileNotFoundError("Model file not found. Please download it first.")
+            raise FileNotFoundError(f"Model file {model_name} not found. Please download it first.")
         device = "cuda" if torch.cuda.is_available() else "cpu"
         model.to(device)
         model.eval()
+        current_model_name = model_name
     return model
 
 class DownloadModelOperator(bpy.types.Operator):
@@ -32,21 +42,32 @@ class DownloadModelOperator(bpy.types.Operator):
     bl_label = "Download DA3 Model"
 
     def execute(self, context):
-        if os.path.exists(MODEL_PATH):
-            self.report({'INFO'}, "Model already downloaded.")
+        model_name = context.scene.da3_model_name
+        model_path = get_model_path(model_name)
+        
+        if os.path.exists(model_path):
+            self.report({'INFO'}, f"Model {model_name} already downloaded.")
             return {'FINISHED'}
+        
+        if model_name not in _URLS:
+            self.report({'ERROR'}, f"Unknown model: {model_name}")
+            return {'CANCELLED'}
+            
         try:
-            print("downloading model...")
-            torch.hub.download_url_to_file(_URL, MODEL_PATH)
-            self.report({'INFO'}, "Model downloaded successfully.")
+            print(f"Downloading model {model_name}...")
+            os.makedirs(MODELS_DIR, exist_ok=True)
+            torch.hub.download_url_to_file(_URLS[model_name], model_path)
+            self.report({'INFO'}, f"Model {model_name} downloaded successfully.")
         except Exception as e:
-            self.report({'ERROR'}, f"Failed to download model: {e}")
+            self.report({'ERROR'}, f"Failed to download model {model_name}: {e}")
             return {'CANCELLED'}
         return {'FINISHED'}
 
     @classmethod
     def poll(cls, context):
-        return not os.path.exists(MODEL_PATH)
+        model_name = context.scene.da3_model_name
+        model_path = get_model_path(model_name)
+        return not os.path.exists(model_path)
 
 
 class GeneratePointCloudOperator(bpy.types.Operator):
@@ -55,11 +76,13 @@ class GeneratePointCloudOperator(bpy.types.Operator):
 
     def execute(self, context):
         input_folder = context.scene.da3_input_folder
+        model_name = context.scene.da3_model_name
+        
         if not input_folder or not os.path.isdir(input_folder):
             self.report({'ERROR'}, "Please select a valid input folder.")
             return {'CANCELLED'}
         try:
-            model = get_model()
+            model = get_model(model_name)
             predictions = run_model(input_folder, model)
             import_point_cloud(predictions)
             self.report({'INFO'}, "Point cloud generated and imported successfully.")
@@ -72,4 +95,6 @@ class GeneratePointCloudOperator(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return os.path.exists(MODEL_PATH) and context.scene.da3_input_folder != ""
+        model_name = context.scene.da3_model_name
+        model_path = get_model_path(model_name)
+        return os.path.exists(model_path) and context.scene.da3_input_folder != ""

--- a/panels.py
+++ b/panels.py
@@ -1,5 +1,5 @@
 import bpy
-from .operators import MODEL_PATH
+from .operators import get_model_path
 import os
 
 class DA3Panel(bpy.types.Panel):
@@ -12,11 +12,18 @@ class DA3Panel(bpy.types.Panel):
     def draw(self, context):
         layout = self.layout
         scene = context.scene
+        
+        # Model selection dropdown
+        layout.prop(scene, "da3_model_name", text="Model")
+        
+        # Download button or status
+        model_path = get_model_path(scene.da3_model_name)
         row = layout.row()
-        if os.path.exists(MODEL_PATH):
-            row.label(text="Model already downloaded")
+        if os.path.exists(model_path):
+            row.label(text=f"Model {scene.da3_model_name} ready")
         else:
-            row.operator("da3.download_model")
+            row.operator("da3.download_model", text=f"Download {scene.da3_model_name}")
+        
         layout.prop(scene, "da3_input_folder", text="Input Folder")
         row = layout.row()
         row.operator("da3.generate_point_cloud")


### PR DESCRIPTION
加载其他模型时需要设置对应的配置文件（默认值是da3-large），否则会加载失败
如：
```python
DepthAnything3(model_name="da3-small")
```
然后顺便加了个下拉选择框方便下载其它模型
<img width="246" height="162" alt="image" src="https://github.com/user-attachments/assets/15df7535-7177-4d9f-9a25-3dc3d6990ee4" />

<img width="246" height="138" alt="image" src="https://github.com/user-attachments/assets/436125db-a8ee-4c7f-a84b-b5b18ad6ef86" />
