### PR TITLE
Add camera intrinsics, calib export, UI improvements, and texturing f…

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -72,6 +72,89 @@ class MoveModelsOperator(bpy.types.Operator):
         self.report({'INFO'}, f"Moved {moved_count} files to {target_dir}")
         return {'FINISHED'}
 
+def _create_torch_preload_script():
+    """Write a Blender startup script that pre-loads CUDA torch before any addon runs.
+
+    Placed in {user_config}/scripts/startup/ so it executes before addons.
+    Uses a relative path (../addons/DA3-blender-main/deps_public) so it works
+    regardless of where Blender's user config lives.
+    """
+    import bpy
+    user_path = Path(bpy.utils.resource_path('USER'))
+    startup_dir = user_path / 'scripts' / 'startup'
+    startup_dir.mkdir(parents=True, exist_ok=True)
+
+    script_path = startup_dir / 'da3_torch_preload.py'
+    script_content = (
+        '"""DA3 Addon - CUDA torch preloader (auto-generated).\n'
+        'Ensures deps_public CUDA torch is loaded before any addon\n'
+        '(including ones that do "import torch" at module level, e.g. GenMM)\n'
+        'can import Blenders bundled CPU-only torch.\n'
+        '"""\n'
+        'import ctypes\n'
+        'import glob as _glob\n'
+        'import sys\n'
+        'from pathlib import Path\n'
+        '\n'
+        '# deps_public is at {user}/scripts/addons/DA3-blender-main/deps_public\n'
+        '_da3_deps = Path(__file__).parent.parent / "addons" / "DA3-blender-main" / "deps_public"\n'
+        'if (_da3_deps / "torch").exists():\n'
+        '    _deps_str = str(_da3_deps)\n'
+        '    if _deps_str not in sys.path:\n'
+        '        sys.path.insert(0, _deps_str)\n'
+        '\n'
+        '    # cuDNN 9.x loads component libs lazily by name only. Pre-load every\n'
+        '    # .so.N file from the pip-installed nvidia packages with RTLD_GLOBAL so\n'
+        '    # those dlopen() calls succeed at inference time.\n'
+        '    _nvidia_dir = str(_da3_deps / "nvidia")\n'
+        '    for _lib_path in sorted(_glob.glob(f"{_nvidia_dir}/*/lib/*.so.*")):\n'
+        '        _base = _lib_path.rsplit(".so.", 1)[-1]\n'
+        '        _parts = _base.split(".")\n'
+        '        if len(_parts) <= 2 and all(p.isdigit() for p in _parts):\n'
+        '            if "nvblas" in _lib_path:\n'
+        '                continue\n'
+        '            try:\n'
+        '                ctypes.CDLL(_lib_path, ctypes.RTLD_GLOBAL)\n'
+        '            except Exception:\n'
+        '                pass\n'
+        '\n'
+        '    # Evict any Blender-bundled torch already in sys.modules\n'
+        '    _to_evict = [n for n in list(sys.modules)\n'
+        '                 if n == "torch" or n.startswith("torch.") or\n'
+        '                    n == "torchvision" or n.startswith("torchvision.")]\n'
+        '    for _m in _to_evict:\n'
+        '        sys.modules.pop(_m, None)\n'
+        '    # Pre-load CUDA torch so it wins the sys.modules race\n'
+        '    try:\n'
+        '        import torch as _da3_torch\n'
+        '        print(f"[DA3] Pre-loaded torch {_da3_torch.__version__} from deps_public "\n'
+        '              f"(CUDA: {_da3_torch.cuda.is_available()})")\n'
+        '        del _da3_torch\n'
+        '    except Exception as _e:\n'
+        '        print(f"[DA3] Warning: could not pre-load torch from deps_public: {_e}")\n'
+        '\n'
+        '    # Some torch CUDA extension libs (e.g. libtorch_cuda_linalg.so) are loaded\n'
+        '    # lazily by name only when first used (e.g. torch.inverse on a CUDA tensor).\n'
+        '    # Pre-loading them with RTLD_GLOBAL after torch is imported ensures dlopen\n'
+        '    # can find them without needing them on LD_LIBRARY_PATH.\n'
+        '    _torch_lib_dir = str(_da3_deps / "torch" / "lib")\n'
+        '    for _lib_name in ("libtorch_cuda_linalg.so",):\n'
+        '        _lib_path = f"{_torch_lib_dir}/{_lib_name}"\n'
+        '        try:\n'
+        '            ctypes.CDLL(_lib_path, ctypes.RTLD_GLOBAL)\n'
+        '            print(f"[DA3] Pre-loaded {_lib_name}")\n'
+        '        except Exception as _e:\n'
+        '            print(f"[DA3] Warning: could not pre-load {_lib_name}: {_e}")\n'
+        '\n'
+        '\n'
+        'def register():\n'
+        '    pass\n'
+    )
+    with open(script_path, 'w') as f:
+        f.write(script_content)
+    print(f'[DA3] Created startup preload script: {script_path}')
+
+
 class DA3InstallDepsOperator(bpy.types.Operator):
     bl_idname = "da3.install_dependencies"
     bl_label = "Install Dependencies"
@@ -80,8 +163,11 @@ class DA3InstallDepsOperator(bpy.types.Operator):
 
     def execute(self, context):
         try:
-            Dependencies.install()
-            self.report({'INFO'}, "Dependencies installed successfully. Please re-enable the addon.")
+            if Dependencies.install():
+                _create_torch_preload_script()
+                self.report({'INFO'}, "Dependencies installed successfully. Please restart Blender.")
+            else:
+                self.report({'ERROR'}, "Failed to install dependencies. Check Blender System Console.")
         except Exception as e:
             self.report({'ERROR'}, f"Failed to install dependencies: {e}")
         return {'FINISHED'}
@@ -149,23 +235,29 @@ def register_classes():
     bpy.types.Scene.da3_ui_model_open = bpy.props.BoolProperty(
         name="Model",
         description="Show/hide model options",
-        default=True,
+        default=False,
     )
     bpy.types.Scene.da3_ui_batch_open = bpy.props.BoolProperty(
         name="Batch",
         description="Show/hide batch options",
-        default=True,
+        default=False,
     )
     bpy.types.Scene.da3_ui_seg_motion_open = bpy.props.BoolProperty(
         name="Segmentation & Motion",
         description="Show/hide segmentation and motion options",
-        default=True,
+        default=False,
     )
 
     bpy.types.Scene.da3_input_folder = bpy.props.StringProperty(
         name="Input Folder / Video",
         description="Folder of images (JPG/PNG) or a video file (mp4, mov, avi, …)",
         subtype='FILE_PATH',
+    )
+    bpy.types.Scene.da3_output_folder = bpy.props.StringProperty(
+        name="Output Folder",
+        description="Folder to save generated data (camera intrinsics CSV, etc.). Leave empty to skip saving.",
+        subtype='DIR_PATH',
+        default="",
     )
     bpy.types.Scene.da3_streaming_output = bpy.props.StringProperty(
         name="Output",
@@ -239,6 +331,18 @@ def register_classes():
         description="Number of images to process in a single batch",
         default=10,
         min=1
+    )
+    bpy.types.Scene.da3_start_frame = bpy.props.IntProperty(
+        name="Start Frame",
+        description="Index of the first frame to process (0 = first image in folder)",
+        default=0,
+        min=0,
+    )
+    bpy.types.Scene.da3_end_frame = bpy.props.IntProperty(
+        name="End Frame",
+        description="Index of the last frame to process (inclusive). -1 means process until the last image.",
+        default=-1,
+        min=-1,
     )
     bpy.types.Scene.da3_frame_stride = bpy.props.IntProperty(
         name="Frame Stride",
@@ -322,7 +426,7 @@ def register_classes():
         ],
         name="Batch Mode",
         description="How to select images for processing",
-        default="skip_frames"
+        default="ignore_batch_size"
     )
     bpy.types.Scene.da3_filter_edges = bpy.props.BoolProperty(
         name="Filter Edges",
@@ -350,6 +454,23 @@ def register_classes():
         name="Animate Sequence",
         description="Keyframe each camera and mesh to be visible only on its corresponding Blender timeline frame",
         default=False,
+    )
+    bpy.types.Scene.da3_keep_individual_cameras = bpy.props.BoolProperty(
+        name="Keep Individual Cameras",
+        description="Also create one static camera object per frame as viewport reference markers (in addition to the animated DA3_Camera)",
+        default=False,
+    )
+    bpy.types.Scene.da3_per_frame_geometry = bpy.props.BoolProperty(
+        name="Per-frame Geometry",
+        description="Show one mesh/point-cloud per frame (appears and disappears with the timeline). Off = all frames combined into one static object",
+        default=False,
+    )
+    bpy.types.Scene.da3_point_scale = bpy.props.FloatProperty(
+        name="Point Scale",
+        description="Size multiplier for point cloud dots (radius = scale × 0.002 scene units)",
+        default=1.0,
+        min=0.01,
+        max=100.0,
     )
     bpy.types.Scene.da3_detect_motion = bpy.props.BoolProperty(
         name="Detect Motion",
@@ -413,6 +534,7 @@ def unregister_classes():
     del bpy.types.Scene.da3_ui_batch_open
     del bpy.types.Scene.da3_ui_seg_motion_open
     del bpy.types.Scene.da3_input_folder
+    del bpy.types.Scene.da3_output_folder
     del bpy.types.Scene.da3_streaming_output
     del bpy.types.Scene.da3_streaming_advanced_open
     del bpy.types.Scene.da3_model_name
@@ -423,6 +545,8 @@ def unregister_classes():
     del bpy.types.Scene.da3_load_half_precision
     del bpy.types.Scene.da3_use_ray_pose
     del bpy.types.Scene.da3_batch_size
+    del bpy.types.Scene.da3_start_frame
+    del bpy.types.Scene.da3_end_frame
     del bpy.types.Scene.da3_frame_stride
     del bpy.types.Scene.da3_ref_view_strategy
     del bpy.types.Scene.da3_streaming_loop_enable
@@ -438,6 +562,9 @@ def unregister_classes():
     del bpy.types.Scene.da3_output_debug_images
     del bpy.types.Scene.da3_generate_mesh
     del bpy.types.Scene.da3_animate_sequence
+    del bpy.types.Scene.da3_keep_individual_cameras
+    del bpy.types.Scene.da3_per_frame_geometry
+    del bpy.types.Scene.da3_point_scale
     del bpy.types.Scene.da3_detect_motion
     del bpy.types.Scene.da3_motion_threshold
     del bpy.types.Scene.da3_use_segmentation

--- a/dependencies.py
+++ b/dependencies.py
@@ -19,6 +19,38 @@ deps_path_da3 = add_on_path / 'deps_da3'
 sys.path.insert(0, os.fspath(deps_path))
 sys.path.insert(0, os.fspath(deps_path_da3))
 sys.path.insert(0, os.fspath(DA3_DIR))
+
+# Blender 4.4+ ships its own torch (CPU-only) in its bundled site-packages.
+# Other addons (e.g. GenMM) import that CPU torch at load time, which would
+# prevent our CUDA-enabled torch from loading due to C-extension ABI conflicts.
+# Strategy: the Blender startup script da3_torch_preload.py (in scripts/startup/)
+# pre-loads deps_public's CUDA torch before any addon runs.  Here we just verify
+# that the correct torch is already loaded.  If not (e.g. startup script was not
+# present), we attempt eviction and re-load as a fallback — but only if the
+# currently-loaded torch is NOT already from deps_public (evicting an already-
+# initialized torch._C causes "function already has a docstring" errors).
+_deps_public_str = os.fspath(deps_path)
+if (deps_path / 'torch').exists():
+    _existing_torch = sys.modules.get('torch')
+    _already_correct = (
+        _existing_torch is not None and
+        _deps_public_str in (getattr(_existing_torch, '__file__', '') or '')
+    )
+    if not _already_correct:
+        # Evict ALL torch/torchvision (wrong version or not loaded yet)
+        _to_evict = [n for n in list(sys.modules)
+                     if n == 'torch' or n.startswith('torch.') or
+                        n == 'torchvision' or n.startswith('torchvision.')]
+        for _mod_name in _to_evict:
+            sys.modules.pop(_mod_name, None)
+        # Pre-load deps_public's torch
+        try:
+            import torch as _da3_torch  # noqa: F401
+            del _da3_torch
+        except Exception as _e:
+            print(f'[DA3] Warning: could not pre-load torch from deps_public: {_e}')
+    del _existing_torch, _already_correct
+
 OPENCV_PINNED = "opencv-python==4.11.0.86"
 
 

--- a/operators.py
+++ b/operators.py
@@ -408,6 +408,24 @@ def get_model(model_name, load_half=False):
     if model is None or current_model_name != model_name or current_model_load_half != load_half:
         from depth_anything_3.api import DepthAnything3
         if torch.cuda.is_available():
+            # Fix: Blender/VirtualGL may set CUDA_VISIBLE_DEVICES="" (empty string).
+            # is_available() uses _cuda_getDeviceCount() directly → returns 1 (True).
+            # device_count() uses NVML + CUDA_VISIBLE_DEVICES → empty string makes
+            # NVML return 0 (not -1), bypassing the _cuda_getDeviceCount() fallback,
+            # so device_count()=0 while the GPU is actually present and usable.
+            # Removing the empty var restores correct device enumeration.
+            _vis_dev = os.environ.get('CUDA_VISIBLE_DEVICES')
+            if _vis_dev is not None and not _vis_dev.strip():
+                print(f"[DA3] Fixing CUDA_VISIBLE_DEVICES (was '{_vis_dev}', resetting to unset)")
+                del os.environ['CUDA_VISIBLE_DEVICES']
+            torch.cuda.init()
+            # Switch to a fresh CUDA stream so DA3 gets a clean cuBLAS handle.
+            # YOLO(model_path) corrupts the current stream's cuBLAS handle even
+            # when YOLO runs on CPU (confirmed: 16x16 GEMM fails after YOLO load
+            # but before any YOLO inference).  cuBLAS handles are per-(device,
+            # stream) in PyTorch, so a new stream gives a fresh, uncorrupted one.
+            _da3_stream = torch.cuda.Stream(device=0)
+            torch.cuda.set_stream(_da3_stream)
             torch.cuda.reset_peak_memory_stats()
         display_VRAM_usage(f"before loading {model_name}")
         config_model_name = CONFIG_NAME_MAP.get(model_name, model_name)
@@ -445,7 +463,7 @@ def get_model(model_name, load_half=False):
         try:
             first_param = next(model.parameters())
             print(f"Model device: {first_param.device}, dtype: {first_param.dtype}")
-            if torch.cuda.is_available():
+            if torch.cuda.is_available() and torch.cuda.device_count() > 0:
                 print(f"CUDA device: {torch.cuda.get_device_name(0)}; reserved: {torch.cuda.memory_reserved()/1024**2:.1f} MB")
             dtype_counts = _summarize_model_dtypes(model)
             print("Model dtype summary (dtype, device -> numel):", dict(dtype_counts))
@@ -473,25 +491,20 @@ def unload_current_model():
             display_VRAM_usage("after unload")
 
 def run_segmentation(image_paths, conf_threshold=0.25, model_name="yolo11x-seg"):
+    import pickle
+    import textwrap
+
     print(f"Loading {model_name} model...")
     display_VRAM_usage("before loading YOLO")
-    try:
-        from ultralytics import YOLO
-    except ImportError:
-        print("Error: ultralytics not installed. Please install it to use segmentation.")
-        return None, None
 
-    # Use selected model
-    # model_name passed as argument
     model_path = get_any_model_path(f"{model_name}.pt")
-    
+
     if not os.path.exists(model_path):
         print(f"Downloading {model_name} to {model_path}...")
         url = _URLS.get(model_name, "")
         if not url:
             print(f"Error: No URL known for {model_name}. Please download {model_name}.pt manually to {os.path.dirname(model_path)}")
             return None, None
-            
         try:
             os.makedirs(os.path.dirname(model_path), exist_ok=True)
             torch.hub.download_url_to_file(url, model_path)
@@ -499,116 +512,184 @@ def run_segmentation(image_paths, conf_threshold=0.25, model_name="yolo11x-seg")
             print(f"Failed to download {model_name}: {e}")
             return None, None
 
-    # Load model from specific path
-    seg_model = YOLO(model_path) 
-    display_VRAM_usage("after loading YOLO", include_peak=True)
-    
-    print(f"Running segmentation on {len(image_paths)} images...")
-    
-    # Run tracking
-    # persist=True is important for video tracking
-    # stream=True returns a generator, good for memory
-    results = seg_model.track(source=image_paths, conf=conf_threshold, persist=True, stream=True, verbose=False)
-    
-    segmentation_data = []
-    
-    for i, r in enumerate(results):
-        # r is a Results object
-        # We need masks and track IDs
-        frame_data = {
-            "masks": [],
-            "ids": [],
-            "classes": [],
-            "orig_shape": r.orig_shape
-        }
-        
-        if r.masks is not None:
-            # masks.data is a torch tensor of masks [N, H, W]
-            masks = r.masks.data.cpu().numpy()
-            
-            # Crop masks to remove letterbox padding (YOLO pads to multiple of 32)
-            # This ensures aspect ratio matches original image before we resize later
-            h_orig, w_orig = r.orig_shape
-            if len(masks.shape) == 3:
-                _, h_mask, w_mask = masks.shape
-                
-                # Calculate scale factor that was used to fit image into mask
-                scale = min(w_mask / w_orig, h_mask / h_orig)
-                
-                # Compute expected dimensions of the valid image area in the mask
-                new_w = int(round(w_orig * scale))
-                new_h = int(round(h_orig * scale))
-                
-                # Compute start offsets (centering)
-                x_off = (w_mask - new_w) // 2
-                y_off = (h_mask - new_h) // 2
-                
-                # Crop
-                masks = masks[:, y_off : y_off + new_h, x_off : x_off + new_w]
-            
-            # Fix edge artifacts (sometimes edges are black)
-            if len(masks.shape) == 3:
-                for k in range(masks.shape[0]):
-                    m = masks[k]
-                    h_m, w_m = m.shape
-                    
-                    # Fix bottom edge
-                    if h_m >= 3:
-                        if np.max(m[-1, :]) == 0:
-                            if np.max(m[-2, :]) == 0:
-                                m[-2:, :] = m[-3, :]
-                            else:
-                                m[-1, :] = m[-2, :]
+    # Run YOLO in an isolated subprocess with CUDA hidden (CUDA_VISIBLE_DEVICES="").
+    # YOLO(model_path) corrupts the process-wide cuBLAS handle even when running on
+    # CPU, causing every subsequent F.linear in DA3 to fail with std::bad_alloc.
+    # A subprocess with no CUDA visibility cannot touch any CUDA state in the main
+    # process, so DA3's cuBLAS handle remains intact.
+    _WORKER = textwrap.dedent("""\
+        import os
+        import sys
+        import pickle
 
-                    # Fix top edge
-                    if h_m >= 3:
-                        if np.max(m[0, :]) == 0:
-                            if np.max(m[1, :]) == 0:
-                                m[:2, :] = m[2, :]
-                            else:
-                                m[0, :] = m[1, :]
+        args_path = sys.argv[1]
+        result_path = sys.argv[2]
 
-                    # Fix left edge
-                    if w_m >= 3:
-                        if np.max(m[:, 0]) == 0:
-                            if np.max(m[:, 1]) == 0:
-                                m[:, :2] = m[:, 2:3]
-                            else:
-                                m[:, 0] = m[:, 1]
+        with open(args_path, 'rb') as f:
+            args = pickle.load(f)
 
-            frame_data["masks"] = masks
-            
-            if r.boxes is not None and r.boxes.id is not None:
-                frame_data["ids"] = r.boxes.id.int().cpu().numpy()
-            else:
-                # If no tracking IDs (e.g. first frame or lost track), use -1 or generate new ones?
-                # If tracking is on, it should return IDs. If not, maybe just detection.
-                # But we requested track().
-                # If no ID, maybe it's a new object that wasn't tracked?
-                # Let's use -1 for untracked
-                if r.boxes is not None:
-                    frame_data["ids"] = np.full(len(r.boxes), -1, dtype=int)
-            
-            if r.boxes is not None:
-                frame_data["classes"] = r.boxes.cls.int().cpu().numpy()
-                
-        segmentation_data.append(frame_data)
-        
-        if i % 10 == 0:
-            print(f"Segmented {i+1}/{len(image_paths)} images")
+        # Prepend deps_public paths so ultralytics / numpy are found correctly.
+        for p in reversed(args['sys_path']):
+            if p not in sys.path:
+                sys.path.insert(0, p)
 
-    display_VRAM_usage("after YOLO inference", include_peak=True)
-    
-    # Get class names
-    class_names = seg_model.names
+        import numpy as np
+        from ultralytics import YOLO
 
-    # Cleanup
-    del seg_model
-    if torch.cuda.is_available():
-        torch.cuda.empty_cache()
-        display_VRAM_usage("after unloading YOLO")
-        
-    return segmentation_data, class_names
+        model_path = args['model_path']
+        image_paths = args['image_paths']
+        conf_threshold = args['conf_threshold']
+
+        seg_model = YOLO(model_path)
+        segmentation_data = []
+        for _imgsz in [640, 320]:
+            segmentation_data = []
+            try:
+                results = seg_model.track(
+                    source=image_paths, conf=conf_threshold,
+                    persist=True, stream=True, verbose=False,
+                    device='cpu', imgsz=_imgsz,
+                )
+                for i, r in enumerate(results):
+                    frame_data = {
+                        "masks": [],
+                        "ids": [],
+                        "classes": [],
+                        "orig_shape": r.orig_shape,
+                    }
+
+                    if r.masks is not None:
+                        masks = r.masks.data.cpu().numpy()
+
+                        h_orig, w_orig = r.orig_shape
+                        if len(masks.shape) == 3:
+                            _, h_mask, w_mask = masks.shape
+                            scale = min(w_mask / w_orig, h_mask / h_orig)
+                            new_w = int(round(w_orig * scale))
+                            new_h = int(round(h_orig * scale))
+                            x_off = (w_mask - new_w) // 2
+                            y_off = (h_mask - new_h) // 2
+                            masks = masks[:, y_off:y_off + new_h, x_off:x_off + new_w]
+
+                        if len(masks.shape) == 3:
+                            for k in range(masks.shape[0]):
+                                m = masks[k]
+                                h_m, w_m = m.shape
+                                if h_m >= 3:
+                                    if np.max(m[-1, :]) == 0:
+                                        if np.max(m[-2, :]) == 0:
+                                            m[-2:, :] = m[-3, :]
+                                        else:
+                                            m[-1, :] = m[-2, :]
+                                if h_m >= 3:
+                                    if np.max(m[0, :]) == 0:
+                                        if np.max(m[1, :]) == 0:
+                                            m[:2, :] = m[2, :]
+                                        else:
+                                            m[0, :] = m[1, :]
+                                if w_m >= 3:
+                                    if np.max(m[:, 0]) == 0:
+                                        if np.max(m[:, 1]) == 0:
+                                            m[:, :2] = m[:, 2:3]
+                                        else:
+                                            m[:, 0] = m[:, 1]
+
+                        frame_data["masks"] = masks
+
+                        if r.boxes is not None and r.boxes.id is not None:
+                            frame_data["ids"] = r.boxes.id.int().cpu().numpy()
+                        else:
+                            if r.boxes is not None:
+                                frame_data["ids"] = np.full(len(r.boxes), -1, dtype=int)
+
+                        if r.boxes is not None:
+                            frame_data["classes"] = r.boxes.cls.int().cpu().numpy()
+
+                    segmentation_data.append(frame_data)
+
+                    if i % 10 == 0:
+                        print(f"Segmented {i+1}/{len(image_paths)} images", flush=True)
+
+                break  # success
+
+            except Exception as e:
+                print(f"[DA3-worker] Segmentation error ({type(e).__name__}) at imgsz={_imgsz}: {e}", flush=True)
+                if 'bad_alloc' in str(e) or 'out of memory' in str(e).lower():
+                    if _imgsz > 320:
+                        print("[DA3-worker] Retrying with imgsz=320 ...", flush=True)
+                        continue
+                    print("[DA3-worker] Segmentation failed at all image sizes.", flush=True)
+                    segmentation_data = None
+                    break
+                import traceback
+                traceback.print_exc()
+                segmentation_data = None
+                break
+
+        class_names = seg_model.names
+        del seg_model
+
+        with open(result_path, 'wb') as f:
+            pickle.dump({"segmentation_data": segmentation_data, "class_names": class_names}, f)
+    """)
+
+    tmp_dir = tempfile.mkdtemp(prefix="da3_yolo_")
+    try:
+        script_path = os.path.join(tmp_dir, "yolo_worker.py")
+        args_path = os.path.join(tmp_dir, "args.pkl")
+        result_path = os.path.join(tmp_dir, "result.pkl")
+
+        with open(script_path, 'w') as f:
+            f.write(_WORKER)
+
+        with open(args_path, 'wb') as f:
+            pickle.dump({
+                'model_path': model_path,
+                'image_paths': image_paths,
+                'conf_threshold': conf_threshold,
+                'sys_path': sys.path,
+            }, f)
+
+        env = os.environ.copy()
+        env['CUDA_VISIBLE_DEVICES'] = ''
+
+        print(f"[DA3] Running YOLO in isolated subprocess (CUDA hidden)...")
+        proc = subprocess.run(
+            [sys.executable, script_path, args_path, result_path],
+            env=env,
+            timeout=600,
+        )
+
+        if proc.returncode != 0:
+            print(f"[DA3] YOLO subprocess failed (return code {proc.returncode})")
+            return None, None
+
+        if not os.path.exists(result_path):
+            print("[DA3] YOLO subprocess produced no output file.")
+            return None, None
+
+        with open(result_path, 'rb') as f:
+            result = pickle.load(f)
+
+        segmentation_data = result.get("segmentation_data")
+        class_names = result.get("class_names")
+
+        if segmentation_data is None:
+            return None, None
+
+        display_VRAM_usage("after YOLO subprocess")
+        return segmentation_data, class_names
+
+    except subprocess.TimeoutExpired:
+        print("[DA3] YOLO subprocess timed out (600 s).")
+        return None, None
+    except Exception as e:
+        print(f"[DA3] YOLO subprocess error: {e}")
+        import traceback
+        traceback.print_exc()
+        return None, None
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
 
 class DownloadModelOperator(bpy.types.Operator):
     bl_idname = "da3.download_model"
@@ -838,7 +919,13 @@ class GeneratePointCloudOperator(bpy.types.Operator):
         self.detect_motion = getattr(context.scene, "da3_detect_motion", False)
         self.motion_threshold = getattr(context.scene, "da3_motion_threshold", 0.1)
         self.animate_sequence = getattr(context.scene, "da3_animate_sequence", False)
-        
+        self.keep_individual_cameras = getattr(context.scene, "da3_keep_individual_cameras", False)
+        self.per_frame_geometry = getattr(context.scene, "da3_per_frame_geometry", False)
+        self.point_scale = getattr(context.scene, "da3_point_scale", 1.0)
+        self.output_folder = getattr(context.scene, "da3_output_folder", "") or ""
+        self.start_frame = getattr(context.scene, "da3_start_frame", 0)
+        self.end_frame = getattr(context.scene, "da3_end_frame", -1)
+
         # Prime the model folder cache in the main thread
         get_configured_model_folder(context)
         
@@ -913,7 +1000,10 @@ class GeneratePointCloudOperator(bpy.types.Operator):
             "generate_mesh": self.generate_mesh,
             "filter_edges": self.filter_edges,
             "min_confidence": self.min_confidence,
-            "animate_sequence": self.animate_sequence
+            "animate_sequence": self.animate_sequence,
+            "keep_individual_cameras": self.keep_individual_cameras,
+            "per_frame_geometry": self.per_frame_geometry,
+            "point_scale": self.point_scale,
         })
 
     def _write_streaming_config(self, model_path, chunk_size, overlap, loop_chunk_size, output_dir, ref_view_strategy):
@@ -1119,7 +1209,8 @@ Loop:
                 if image_paths:
                     preds["image_paths"] = image_paths
 
-                create_cameras(preds, collection=_collection, image_width=image_width, image_height=image_height)
+                _src_name = os.path.basename(os.path.normpath(getattr(self, "input_folder", _output_dir) or _output_dir))
+                create_cameras(preds, collection=_collection, image_width=image_width, image_height=image_height, output_path=_output_dir, source_name=_src_name)
                 return True
 
             # Unified parity path: segmentation, mesh, or motion (non-chunk import)
@@ -1329,7 +1420,10 @@ Loop:
 
                                 # Add image paths for texturing
                                 from pathlib import Path
-                                image_list = sorted(list(Path(self.input_folder).glob("*.png")))
+                                image_list = sorted(
+                                    p for ext in ("*.png", "*.PNG", "*.jpg", "*.JPG", "*.jpeg", "*.JPEG")
+                                    for p in Path(self.input_folder).glob(ext)
+                                )
                                 chunk_size = 10
                                 overlap = 5
                                 start_idx = idx * (chunk_size - overlap)
@@ -1425,12 +1519,23 @@ Loop:
         try:
             # Get image paths
             import glob
-            self.image_paths = sorted(glob.glob(os.path.join(self.input_folder, "*.[jJpP][pPnN][gG]")))
+            _img_exts = ("*.png", "*.PNG", "*.jpg", "*.JPG", "*.jpeg", "*.JPEG")
+            self.image_paths = sorted(
+                p for ext in _img_exts
+                for p in glob.glob(os.path.join(self.input_folder, ext))
+            )
             if not self.image_paths:
                 self.result_queue.put({"type": "ERROR", "message": "No images found in the input folder."})
                 return
             
             print(f"Total images: {len(self.image_paths)}")
+
+            # Apply start/end frame range
+            start = self.start_frame
+            end = self.end_frame if self.end_frame >= 0 else len(self.image_paths)
+            self.image_paths = self.image_paths[start:end + 1 if self.end_frame >= 0 else end]
+            if start > 0 or self.end_frame >= 0:
+                print(f"After frame range [{start}:{self.end_frame}]: {len(self.image_paths)} images")
 
             # Apply frame stride subsampling
             frame_stride = getattr(context.scene, "da3_frame_stride", 1)
@@ -1958,7 +2063,10 @@ Loop:
             filter_edges = msg["filter_edges"]
             min_confidence = msg["min_confidence"]
             animate_sequence = msg.get("animate_sequence", False)
-            
+            keep_individual_cameras = msg.get("keep_individual_cameras", False)
+            per_frame_geometry = msg.get("per_frame_geometry", False)
+            point_scale = msg.get("point_scale", 1.0)
+
             parent_col = self.parent_col
             if not parent_col:
                 parent_col = bpy.data.collections.new(folder_name)
@@ -1969,11 +2077,28 @@ Loop:
             parent_col.children.link(batch_col)
             
             if generate_mesh:
-                import_mesh_from_depth(combined_predictions, collection=batch_col, filter_edges=filter_edges, min_confidence=min_confidence, global_indices=batch_indices, animate_sequence=animate_sequence)
+                import_mesh_from_depth(combined_predictions, collection=batch_col, filter_edges=filter_edges, min_confidence=min_confidence, global_indices=batch_indices, per_frame_geometry=per_frame_geometry)
             else:
-                import_point_cloud(combined_predictions, collection=batch_col, filter_edges=filter_edges, min_confidence=min_confidence, global_indices=batch_indices)
+                import_point_cloud(combined_predictions, collection=batch_col, filter_edges=filter_edges, min_confidence=min_confidence, global_indices=batch_indices, per_frame_geometry=per_frame_geometry, point_scale=point_scale)
 
-            create_cameras(combined_predictions, collection=batch_col, animate_sequence=animate_sequence, global_indices=batch_indices)
+            _out = getattr(self, "output_folder", "") or getattr(self, "input_folder", None)
+            # Derive a meaningful source name for calib file naming.
+            # For video inputs _input_display_name is the video stem (always good).
+            # For image folders, folder_name is the direct parent dir of the images —
+            # when that's a generic staging name ("output", "frames", etc.) climb up
+            # one level to get the shot/sequence name instead.
+            _GENERIC_DIRS = {"output", "images", "frames", "input", "img", "imgs",
+                             "photos", "raw", "renders", "render", "data", "src", "export"}
+            _display = getattr(self, "_input_display_name", None)
+            if _display:
+                _source_name = _display
+            elif folder_name.lower() in _GENERIC_DIRS:
+                _parent = os.path.basename(os.path.dirname(
+                    os.path.normpath(getattr(self, "input_folder", "") or "")))
+                _source_name = _parent or folder_name
+            else:
+                _source_name = folder_name
+            create_cameras(combined_predictions, collection=batch_col, animate_sequence=animate_sequence, global_indices=batch_indices, keep_individual_cameras=keep_individual_cameras, output_path=_out or None, source_name=_source_name)
         except Exception as e:
             # end_progress_timer()
             import traceback

--- a/panels.py
+++ b/panels.py
@@ -58,6 +58,7 @@ class DA3Panel(bpy.types.Panel):
 
         # Input folder stays prominent
         layout.prop(scene, "da3_input_folder", text="Input Folder / Video")
+        layout.prop(scene, "da3_output_folder", text="Output Folder")
 
         # --- Resolution (non-collapsible) ---
         res_box = layout.box()
@@ -83,6 +84,9 @@ class DA3Panel(bpy.types.Panel):
                 batch_box.prop(scene, "da3_batch_size", text="Batch Size")
             if scene.da3_batch_mode != "skip_frames":
                 batch_box.prop(scene, "da3_frame_stride", text="Frame Stride")
+            row = batch_box.row(align=True)
+            row.prop(scene, "da3_start_frame", text="Start Frame")
+            row.prop(scene, "da3_end_frame", text="End Frame")
             batch_box.prop(scene, "da3_ref_view_strategy", text="Ref View Strategy")
 
             if scene.da3_batch_mode == "da3_streaming":
@@ -137,8 +141,14 @@ class DA3Panel(bpy.types.Panel):
                 sm_box.separator()
 
         layout.prop(scene, "da3_generate_mesh", text="Generate Meshes")
-        if scene.da3_generate_mesh:
-            layout.prop(scene, "da3_animate_sequence", text="Animate Sequence")
+        layout.prop(scene, "da3_animate_sequence", text="Animate Sequence")
+        if scene.da3_animate_sequence:
+            row = layout.row()
+            row.separator(factor=2.0)
+            row.prop(scene, "da3_keep_individual_cameras", text="Keep Individual Cameras")
+        layout.prop(scene, "da3_per_frame_geometry", text="Per-frame Geometry")
+        if not scene.da3_generate_mesh:
+            layout.prop(scene, "da3_point_scale", text="Point Scale")
         layout.prop(scene, "da3_output_debug_images", text="Output Debug Images")
         row = layout.row()
         row.operator("da3.generate_point_cloud")

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,6 @@
 import glob
 import os
+import tempfile
 import numpy as np
 import bpy
 from mathutils import Matrix
@@ -875,23 +876,32 @@ def get_or_create_point_material():
         links.new(bsdf.outputs['BSDF'], output_node_material.inputs['Surface'])
     return mat
 
-def add_point_cloud_geo_nodes(obj, mat):
+def add_point_cloud_geo_nodes(obj, mat, scale=1.0):
     geo_mod = obj.modifiers.new(name="GeometryNodes", type='NODES')
     node_group = bpy.data.node_groups.new(name="PointCloud", type='GeometryNodeTree')
-    
+
     # Inputs
     node_group.interface.new_socket(name="Geometry", in_out="INPUT", socket_type="NodeSocketGeometry")
     node_group.interface.new_socket(name="Threshold", in_out="INPUT", socket_type="NodeSocketFloat")
     node_group.interface.items_tree[-1].default_value = 0.5
     node_group.interface.new_socket(name="Scale", in_out="INPUT", socket_type="NodeSocketFloat")
-    node_group.interface.items_tree[-1].default_value = 1.0
+    node_group.interface.items_tree[-1].default_value = scale
     node_group.interface.items_tree[-1].min_value = 0.0
     
     # Outputs
     node_group.interface.new_socket(name="Geometry", in_out="OUTPUT", socket_type="NodeSocketGeometry")
     
     geo_mod.node_group = node_group
-    
+
+    # Apply scale value to this modifier instance (override the node-group default)
+    try:
+        for item in node_group.interface.items_tree:
+            if item.name == "Scale":
+                geo_mod[item.identifier] = float(scale)
+                break
+    except Exception:
+        pass
+
     # Nodes
     input_node = node_group.nodes.new('NodeGroupInput')
     output_node = node_group.nodes.new('NodeGroupOutput')
@@ -930,7 +940,7 @@ def add_point_cloud_geo_nodes(obj, mat):
     node_group.links.new(delete_geo.outputs['Geometry'], set_material_node.inputs['Geometry'])
     node_group.links.new(set_material_node.outputs['Geometry'], output_node.inputs['Geometry'])
 
-def create_point_cloud_object(name, points, colors, confs, motions=None, collection=None):
+def create_point_cloud_object(name, points, colors, confs, motions=None, collection=None, scale=1.0):
     mesh = bpy.data.meshes.new(name=name)
     mesh.from_pydata(points.tolist(), [], [])
     
@@ -962,7 +972,7 @@ def create_point_cloud_object(name, points, colors, confs, motions=None, collect
     obj.data.materials.append(mat)
     
     # Geometry nodes setup
-    add_point_cloud_geo_nodes(obj, mat)
+    add_point_cloud_geo_nodes(obj, mat, scale=scale)
     return obj
 
 def apply_edge_filtering(prediction, filter_edges=True, edge_confidence=0.0):
@@ -999,7 +1009,7 @@ def apply_edge_filtering(prediction, filter_edges=True, edge_confidence=0.0):
     except Exception as e:
         print(f"Failed to filter confidence by gradient: {e}")
 
-def import_point_cloud(d, collection=None, filter_edges=True, min_confidence=0.5, global_indices=None):
+def import_point_cloud(d, collection=None, filter_edges=True, min_confidence=0.5, global_indices=None, per_frame_geometry=False, point_scale=1.0):
     # Apply edge filtering if requested
     if isinstance(d, dict) and filter_edges:
         # For dict format (legacy), apply filtering here
@@ -1171,7 +1181,39 @@ def import_point_cloud(d, collection=None, filter_edges=True, min_confidence=0.5
         if stationary_points:
             create_point_cloud_object("Points", np.vstack(stationary_points), np.vstack(stationary_colors), np.concatenate(stationary_confs), np.concatenate(stationary_motions), collection)
 
+    elif per_frame_geometry:
+        # Per-frame mode: one point cloud per frame with keyframed visibility
+        N = points.shape[0]
+        for i in range(N):
+            p = points[i].reshape(-1, 3)
+            reordered = p.copy()
+            reordered[:, [0, 1, 2]] = p[:, [0, 2, 1]]
+            reordered[:, 2] = -reordered[:, 2]
+            c = images[i].reshape(-1, 3)
+            c = np.hstack((c, np.ones((c.shape[0], 1))))
+            cf = conf[i].reshape(-1)
+
+            if min_confidence > 0:
+                mask = cf >= min_confidence
+                reordered = reordered[mask]
+                c = c[mask]
+                cf = cf[mask]
+
+            if len(cf) == 0:
+                continue
+
+            if "image_paths" in d and i < len(d["image_paths"]):
+                name = os.path.splitext(os.path.basename(d["image_paths"][i]))[0]
+                frame_num = _frame_number_from_path(d["image_paths"][i], global_indices[i] if global_indices is not None else i)
+            else:
+                name = f"Points_frame_{i}"
+                frame_num = (global_indices[i] + 1) if global_indices is not None else (i + 1)
+
+            obj = create_point_cloud_object(name, reordered, c, cf, None, collection, scale=point_scale)
+            _keyframe_visibility(obj, frame_num)
+
     else:
+        # Combined mode (default): merge all frames into one object
         points_batch = points.reshape(-1, 3)
         reordered_points_batch = points_batch.copy()
         reordered_points_batch[:, [0, 1, 2]] = points_batch[:, [0, 2, 1]]
@@ -1180,18 +1222,17 @@ def import_point_cloud(d, collection=None, filter_edges=True, min_confidence=0.5
         colors_batch = images.reshape(-1, 3)
         colors_batch = np.hstack((colors_batch, np.ones((colors_batch.shape[0], 1))))
         conf_batch = conf.reshape(-1)
-        
-        # Remove points with low confidence
+
         if min_confidence > 0:
             valid_mask = conf_batch >= min_confidence
             points_batch = points_batch[valid_mask]
             colors_batch = colors_batch[valid_mask]
             conf_batch = conf_batch[valid_mask]
-        
+
         if len(conf_batch) > 0:
             print(f"DEBUG confidence: min={conf_batch.min():.4f}, max={conf_batch.max():.4f}")
-        
-        create_point_cloud_object("Points", points_batch, colors_batch, conf_batch, None, collection)
+
+        create_point_cloud_object("Points", points_batch, colors_batch, conf_batch, None, collection, scale=point_scale)
     
 def _frame_number_from_path(image_path, fallback_index):
     """Return a 1-indexed Blender frame number for an image.
@@ -1218,7 +1259,7 @@ def _keyframe_visibility(obj, frame_number):
                     kp.interpolation = 'CONSTANT'
 
 
-def create_cameras(predictions, collection=None, image_width=None, image_height=None, animate_sequence=False, global_indices=None):
+def create_cameras(predictions, collection=None, image_width=None, image_height=None, animate_sequence=False, global_indices=None, keep_individual_cameras=True, output_path=None, source_name=None):
     scene = bpy.context.scene
     if image_width is None or image_height is None:
         H, W = predictions['images'].shape[1:3]
@@ -1243,6 +1284,25 @@ def create_cameras(predictions, collection=None, image_width=None, image_height=
         target_collection = cameras_col
 
     T = np.diag([1.0, -1.0, -1.0, 1.0])
+    R = Matrix.Rotation(math.radians(-90), 4, 'X')
+
+    # When animating, create one camera that follows the trajectory via keyframes.
+    # Individual cameras are kept as static reference markers but are not animated.
+    anim_cam_obj = None
+    anim_cam_data = None
+    if animate_sequence:
+        # Always create a fresh camera so repeated runs don't mix keyframes.
+        # Blender will auto-rename (DA3_Camera, DA3_Camera.001, ...) if needed.
+        anim_cam_data = bpy.data.cameras.new(name="DA3_Camera")
+        anim_cam_data.sensor_width = 36.0
+        anim_cam_obj = bpy.data.objects.new(name="DA3_Camera", object_data=anim_cam_data)
+        if target_collection is not None:
+            target_collection.objects.link(anim_cam_obj)
+        else:
+            scene.collection.objects.link(anim_cam_obj)
+
+    all_intrinsic_records = []
+
     for i in range(num_cameras):
         # Name from image file if available
         image_path_i = None
@@ -1256,22 +1316,43 @@ def create_cameras(predictions, collection=None, image_width=None, image_height=
 
         cam_data = bpy.data.cameras.new(name=cam_name)
         K = predictions["intrinsic"][i]
-        f_x = K[0,0]
-        c_x = K[0,2]
-        c_y = K[1,2]
+        f_x = float(K[0, 0])
+        f_y = float(K[1, 1])
+        c_x = float(K[0, 2])
+        c_y = float(K[1, 2])
         sensor_width = 36.0
         cam_data.sensor_width = sensor_width
         cam_data.lens = (f_x / image_width) * sensor_width
         cam_data.shift_x = (c_x - image_width / 2.0) / image_width
         cam_data.shift_y = (c_y - image_height / 2.0) / image_height
+
+        # Store raw intrinsics as custom properties (visible in Properties > Camera > Custom Properties)
+        fov_h = math.degrees(2.0 * math.atan(image_width / (2.0 * f_x)))
+        fov_v = math.degrees(2.0 * math.atan(image_height / (2.0 * f_y)))
+        cam_data["fx"] = round(f_x, 4)
+        cam_data["fy"] = round(f_y, 4)
+        cam_data["cx"] = round(c_x, 4)
+        cam_data["cy"] = round(c_y, 4)
+        cam_data["fov_h_deg"] = round(fov_h, 2)
+        cam_data["fov_v_deg"] = round(fov_v, 2)
+
         cam_obj = bpy.data.objects.new(name=cam_name, object_data=cam_data)
 
-        if target_collection is not None:
-            target_collection.objects.link(cam_obj)
-        else:
-            scene.collection.objects.link(cam_obj)
-        
         ext = predictions["extrinsic"][i]
+
+        # Compute frame number (used for keyframing and intrinsic records)
+        if image_path_i:
+            frame_num = _frame_number_from_path(image_path_i, global_indices[i] if global_indices is not None else i)
+        else:
+            frame_num = (global_indices[i] + 1) if global_indices is not None else (i + 1)
+
+        all_intrinsic_records.append({
+            "frame": frame_num,
+            "name": cam_name,
+            "fx": f_x, "fy": f_y,
+            "cx": c_x, "cy": c_y,
+            "fov_h_deg": fov_h, "fov_v_deg": fov_v,
+        })
 
         # Debug print: filename + intrinsics/extrinsics per camera
         try:
@@ -1301,54 +1382,224 @@ def create_cameras(predictions, collection=None, image_width=None, image_height=
         E = np.vstack((ext, [0, 0, 0, 1]))
         E_inv = np.linalg.inv(E)
         M = np.dot(E_inv, T)
-        cam_obj.matrix_world = Matrix(M.tolist())
-        R = Matrix.Rotation(math.radians(-90), 4, 'X')
-        cam_obj.matrix_world = R @ cam_obj.matrix_world
+        cam_obj.matrix_world = R @ Matrix(M.tolist())
 
         if animate_sequence:
-            if image_path_i:
-                frame_num = _frame_number_from_path(image_path_i, global_indices[i] if global_indices is not None else i)
+            # Move the animated camera to this position and keyframe it.
+            anim_cam_obj.matrix_world = cam_obj.matrix_world.copy()
+            anim_cam_obj.keyframe_insert(data_path="location", frame=frame_num)
+            anim_cam_obj.keyframe_insert(data_path="rotation_euler", frame=frame_num)
+            anim_cam_data.lens = cam_data.lens
+            anim_cam_data.shift_x = cam_data.shift_x
+            anim_cam_data.shift_y = cam_data.shift_y
+            anim_cam_data.keyframe_insert(data_path="lens", frame=frame_num)
+            anim_cam_data.keyframe_insert(data_path="shift_x", frame=frame_num)
+            anim_cam_data.keyframe_insert(data_path="shift_y", frame=frame_num)
+
+        # Link individual camera to the scene, or discard it if not needed.
+        if not animate_sequence or keep_individual_cameras:
+            if target_collection is not None:
+                target_collection.objects.link(cam_obj)
             else:
-                frame_num = (global_indices[i] + 1) if global_indices is not None else (i + 1)
-            _keyframe_visibility(cam_obj, frame_num)
+                scene.collection.objects.link(cam_obj)
+        else:
+            bpy.data.objects.remove(cam_obj)
+            bpy.data.cameras.remove(cam_data)
+
+    # --- Consensus intrinsics (median across all frames) ---
+    # Robust approximation for fixed-camera sequences; also useful for moving cameras
+    # as a "typical" intrinsic when the model predictions vary slightly frame-to-frame.
+    if all_intrinsic_records:
+        fx_arr = np.array([r["fx"] for r in all_intrinsic_records])
+        fy_arr = np.array([r["fy"] for r in all_intrinsic_records])
+        cx_arr = np.array([r["cx"] for r in all_intrinsic_records])
+        cy_arr = np.array([r["cy"] for r in all_intrinsic_records])
+
+        med_fx = float(np.median(fx_arr))
+        med_fy = float(np.median(fy_arr))
+        med_cx = float(np.median(cx_arr))
+        med_cy = float(np.median(cy_arr))
+        std_fx = float(np.std(fx_arr))
+        std_fy = float(np.std(fy_arr))
+        med_fov_h = math.degrees(2.0 * math.atan(image_width / (2.0 * med_fx)))
+        med_fov_v = math.degrees(2.0 * math.atan(image_height / (2.0 * med_fy)))
+
+        # Store consensus on the animated camera data block so it's easy to find
+        if anim_cam_data is not None:
+            anim_cam_data["consensus_fx"] = round(med_fx, 4)
+            anim_cam_data["consensus_fy"] = round(med_fy, 4)
+            anim_cam_data["consensus_cx"] = round(med_cx, 4)
+            anim_cam_data["consensus_cy"] = round(med_cy, 4)
+            anim_cam_data["consensus_fov_h_deg"] = round(med_fov_h, 2)
+            anim_cam_data["consensus_fov_v_deg"] = round(med_fov_v, 2)
+            anim_cam_data["std_fx"] = round(std_fx, 4)
+            anim_cam_data["std_fy"] = round(std_fy, 4)
+
+        # Build a human-readable intrinsics report and save it as a Blender text block
+        lines = [
+            "DA3 Camera Intrinsics Report",
+            "=" * 60,
+            f"Frames : {len(all_intrinsic_records)}",
+            f"Image  : {image_width} x {image_height} px",
+            "",
+            "--- Consensus (median) — fixed-camera approximation ---",
+            f"  fx = {med_fx:.4f}  (std: {std_fx:.4f})",
+            f"  fy = {med_fy:.4f}  (std: {std_fy:.4f})",
+            f"  cx = {med_cx:.4f}",
+            f"  cy = {med_cy:.4f}",
+            f"  FOV horizontal = {med_fov_h:.2f} deg",
+            f"  FOV vertical   = {med_fov_v:.2f} deg",
+            "  K =",
+            f"    [ {med_fx:>10.4f}    0.0000    {med_cx:>10.4f} ]",
+            f"    [    0.0000  {med_fy:>10.4f}    {med_cy:>10.4f} ]",
+            f"    [    0.0000    0.0000       1.0000 ]",
+            "",
+            "--- Per-frame intrinsics ---",
+            f"  {'frame':>6}  {'name':<24}  {'fx':>10}  {'fy':>10}  {'cx':>8}  {'cy':>8}  {'fov_h°':>7}  {'fov_v°':>7}",
+            "  " + "-" * 96,
+        ]
+        for r in all_intrinsic_records:
+            lines.append(
+                f"  {r['frame']:>6}  {r['name']:<24}  {r['fx']:>10.4f}  {r['fy']:>10.4f}"
+                f"  {r['cx']:>8.4f}  {r['cy']:>8.4f}  {r['fov_h_deg']:>7.2f}  {r['fov_v_deg']:>7.2f}"
+            )
+        text_content = "\n".join(lines) + "\n"
+
+        txt_name = "DA3_Camera_Intrinsics"
+        txt = bpy.data.texts.get(txt_name)
+        if txt is None:
+            txt = bpy.data.texts.new(txt_name)
+        txt.clear()
+        txt.write(text_content)
+        print(f"[DA3] Intrinsics report written to Blender text block '{txt.name}' "
+              f"(consensus: fx={med_fx:.2f}, fy={med_fy:.2f}, fov_h={med_fov_h:.1f}°)")
+
+        # Write CSV + calib files alongside the input images for external use
+        if output_path:
+            try:
+                import csv
+                csv_path = os.path.join(output_path, "camera_intrinsics.csv")
+                with open(csv_path, "w", newline="") as f:
+                    writer = csv.DictWriter(f, fieldnames=["frame", "name", "fx", "fy", "cx", "cy", "fov_h_deg", "fov_v_deg"])
+                    writer.writeheader()
+                    writer.writerows(all_intrinsic_records)
+                print(f"[DA3] Intrinsics CSV saved: {csv_path}")
+            except Exception as e:
+                print(f"[DA3] Warning: could not write intrinsics CSV: {e}")
+
+            # Derive a clean stem from source_name (strip extension if it's a video filename)
+            _stem = os.path.splitext(source_name)[0] if source_name else "calib"
+
+            # calib_{name}_da3.txt — consensus intrinsics at DA3's processed resolution
+            # (same coordinate space as the CSV / custom properties)
+            try:
+                calib_da3_path = os.path.join(output_path, f"calib_{_stem}_da3.txt")
+                with open(calib_da3_path, "w") as f:
+                    f.write(f"{med_fx:.6f} {med_fy:.6f} {med_cx:.6f} {med_cy:.6f}\n")
+                print(f"[DA3] {os.path.basename(calib_da3_path)} saved (processed res {image_width}x{image_height}): {calib_da3_path}")
+            except Exception as e:
+                print(f"[DA3] Warning: could not write calib_da3 file: {e}")
+
+            # calib_{name}.txt — consensus intrinsics scaled to original image resolution,
+            # ready to use directly with DROID-SLAM (--calib) and ViPE.
+            # Scaling: fx_orig = fx_da3 * (W_orig / W_da3), similarly for fy, cx, cy.
+            try:
+                orig_w, orig_h = image_width, image_height  # fallback = processed res
+                first_path = predictions.get("image_paths", [None])[0] if predictions.get("image_paths") else None
+                if first_path and os.path.isfile(first_path):
+                    _img = cv2.imread(first_path)
+                    if _img is not None:
+                        orig_h, orig_w = _img.shape[:2]
+                scale_x = orig_w / image_width
+                scale_y = orig_h / image_height
+                orig_fx = med_fx * scale_x
+                orig_fy = med_fy * scale_y
+                orig_cx = med_cx * scale_x
+                orig_cy = med_cy * scale_y
+                calib_path = os.path.join(output_path, f"calib_{_stem}.txt")
+                with open(calib_path, "w") as f:
+                    f.write(f"{orig_fx:.6f} {orig_fy:.6f} {orig_cx:.6f} {orig_cy:.6f}\n")
+                print(
+                    f"[DA3] {os.path.basename(calib_path)} saved (original res {orig_w}x{orig_h}, "
+                    f"scale {scale_x:.3f}x{scale_y:.3f}): {calib_path}"
+                )
+                # Also append the original-resolution values to the Blender text block
+                orig_fov_h = math.degrees(2.0 * math.atan(orig_w / (2.0 * orig_fx)))
+                orig_fov_v = math.degrees(2.0 * math.atan(orig_h / (2.0 * orig_fy)))
+                addendum = (
+                    f"\n--- {os.path.basename(calib_path)} (original resolution {orig_w}x{orig_h}) ---\n"
+                    f"  fx = {orig_fx:.4f}   fy = {orig_fy:.4f}\n"
+                    f"  cx = {orig_cx:.4f}   cy = {orig_cy:.4f}\n"
+                    f"  FOV horizontal = {orig_fov_h:.2f} deg\n"
+                    f"  FOV vertical   = {orig_fov_v:.2f} deg\n"
+                    f"  (scale factor: {scale_x:.4f} x, {scale_y:.4f} y)\n"
+                    f"  File: {calib_path}\n"
+                )
+                txt = bpy.data.texts.get(txt_name)
+                if txt is not None:
+                    txt.write(addendum)
+            except Exception as e:
+                print(f"[DA3] Warning: could not write calib.txt: {e}")
 
 def get_or_create_image_material(image_path):
-    name = os.path.basename(image_path)
-    mat = bpy.data.materials.get(name)
+    abs_path = os.path.abspath(image_path)
+
+    # Find image by filepath (not name) to avoid stale-cache bugs across runs
+    img = None
+    for existing in bpy.data.images:
+        try:
+            if os.path.abspath(bpy.path.abspath(existing.filepath)) == abs_path:
+                img = existing
+                break
+        except Exception:
+            pass
+    if img is None:
+        try:
+            img = bpy.data.images.load(image_path)
+            # Pack images from temp dirs so they survive temp cleanup
+            if img is not None and abs_path.startswith(tempfile.gettempdir()):
+                img.pack()
+        except Exception as e:
+            print(f"[DA3] Could not load image {image_path}: {e}")
+
+    # Validate cached material actually has the correct image; recreate if not
+    mat_name = os.path.basename(image_path)
+    mat = bpy.data.materials.get(mat_name)
+    if mat is not None and img is not None:
+        correct = (
+            mat.use_nodes and mat.node_tree is not None and
+            any(n.type == 'TEX_IMAGE' and n.image == img
+                for n in mat.node_tree.nodes)
+        )
+        if not correct:
+            mat = None  # force recreate
+
     if mat is None:
-        mat = bpy.data.materials.new(name=name)
+        mat = bpy.data.materials.new(name=mat_name)
         mat.use_nodes = True
         nodes = mat.node_tree.nodes
         links = mat.node_tree.links
         nodes.clear()
-        
+
         tex_coord = nodes.new('ShaderNodeTexCoord')
         tex_coord.location = (-800, 200)
-        
+
         tex_image = nodes.new('ShaderNodeTexImage')
         tex_image.location = (-500, 200)
-        try:
-            # Check if image is already loaded
-            img_name = os.path.basename(image_path)
-            img = bpy.data.images.get(img_name)
-            if img is None:
-                img = bpy.data.images.load(image_path)
+        if img is not None:
             tex_image.image = img
-        except Exception as e:
-            print(f"Could not load image {image_path}: {e}")
-            
+
         bsdf = nodes.new('ShaderNodeBsdfPrincipled')
         bsdf.location = (-200, 200)
         bsdf.inputs['Roughness'].default_value = 1.0
-        # Try to set specular to 0 to avoid shiny photos
         if 'Specular IOR Level' in bsdf.inputs:
             bsdf.inputs['Specular IOR Level'].default_value = 0.0
         elif 'Specular' in bsdf.inputs:
             bsdf.inputs['Specular'].default_value = 0.0
-        
+
         output = nodes.new('ShaderNodeOutputMaterial')
         output.location = (100, 200)
-        
+
         links.new(tex_coord.outputs['UV'], tex_image.inputs['Vector'])
         links.new(tex_image.outputs['Color'], bsdf.inputs['Base Color'])
         links.new(bsdf.outputs['BSDF'], output.inputs['Surface'])
@@ -1429,7 +1680,7 @@ def add_filter_mesh_modifier(obj, min_confidence):
         
     mod.node_group = group
 
-def import_mesh_from_depth(d, collection=None, filter_edges=True, min_confidence=0.5, global_indices=None, animate_sequence=False):
+def import_mesh_from_depth(d, collection=None, filter_edges=True, min_confidence=0.5, global_indices=None, per_frame_geometry=False):
     points = d["world_points_from_depth"] # [N, H, W, 3]
     images = d["images"] # [N, H, W, 3]
     conf = d["conf"] # [N, H, W]
@@ -1581,7 +1832,7 @@ def import_mesh_from_depth(d, collection=None, filter_edges=True, min_confidence
                 
                 target_col.objects.link(obj)
 
-                if animate_sequence:
+                if per_frame_geometry:
                     if "image_paths" in d and i < len(d["image_paths"]):
                         frame_num = _frame_number_from_path(d["image_paths"][i], global_indices[i] if global_indices is not None else i)
                     else:
@@ -1681,7 +1932,7 @@ def import_mesh_from_depth(d, collection=None, filter_edges=True, min_confidence
                     add_filter_mesh_modifier(obj, min_confidence)
                     
                 # Animation
-                if animate_sequence:
+                if per_frame_geometry:
                     if "image_paths" in d and i < len(d["image_paths"]):
                         frame_num = _frame_number_from_path(d["image_paths"][i], global_indices[i] if global_indices is not None else i)
                     else:
@@ -1755,7 +2006,7 @@ def import_mesh_from_depth(d, collection=None, filter_edges=True, min_confidence
                 else:
                     bpy.context.collection.objects.link(obj)
 
-                if animate_sequence:
+                if per_frame_geometry:
                     if "image_paths" in d and i < len(d["image_paths"]):
                         frame_num = _frame_number_from_path(d["image_paths"][i], global_indices[i] if global_indices is not None else i)
                     else:
@@ -1774,6 +2025,12 @@ def import_mesh_from_depth(d, collection=None, filter_edges=True, min_confidence
                     add_filter_mesh_modifier(obj, min_confidence)
 
     else:
+        # Create a Meshes sub-collection to avoid cluttering the batch collection directly.
+        meshes_col = None
+        if collection:
+            meshes_col = bpy.data.collections.new("Meshes")
+            collection.children.link(meshes_col)
+
         for i in range(N):
             # Prepare data for this image
             pts = points[i].reshape(-1, 3)
@@ -1781,15 +2038,15 @@ def import_mesh_from_depth(d, collection=None, filter_edges=True, min_confidence
             pts_transformed = pts.copy()
             pts_transformed[:, [0, 1, 2]] = pts[:, [0, 2, 1]]
             pts_transformed[:, 2] = -pts_transformed[:, 2]
-            
+
             cols = images[i].reshape(-1, 3)
             cols = np.hstack((cols, np.ones((cols.shape[0], 1)))) # RGBA
             confs = conf[i].reshape(-1)
-            
+
             motion_vals = None
             if 'motion' in d:
                 motion_vals = d['motion'][i].reshape(-1)
-            
+
             # Create Mesh
             if "image_paths" in d and i < len(d["image_paths"]):
                 base_name = os.path.splitext(os.path.basename(d["image_paths"][i]))[0]
@@ -1822,12 +2079,12 @@ def import_mesh_from_depth(d, collection=None, filter_edges=True, min_confidence
                 motion_attr.data.foreach_set("value", motion_vals)
             
             obj = bpy.data.objects.new(mesh_name, mesh)
-            if collection:
-                collection.objects.link(obj)
+            if meshes_col:
+                meshes_col.objects.link(obj)
             else:
                 bpy.context.collection.objects.link(obj)
 
-            if animate_sequence:
+            if per_frame_geometry:
                 if "image_paths" in d and i < len(d["image_paths"]):
                     frame_num = _frame_number_from_path(d["image_paths"][i], global_indices[i] if global_indices is not None else i)
                 else:


### PR DESCRIPTION
Added a bunch of new features and fixed some existing ones:

https://github.com/user-attachments/assets/208d1bbc-5be5-40a7-8281-b62135849137

- Save per-frame fx/fy/cx/cy as custom properties on camera data blocks
- Write DA3_Camera_Intrinsics text block with per-frame table and consensus K
- Export calib_<name>_da3.txt (processed res) and calib_<name>.txt (original res)
- Add output folder, start/end frame range, per-frame geometry toggle, point scale slider
- Decouple animate_sequence (cameras) from per_frame_geometry (mesh/cloud visibility)
- Per-frame point cloud option alongside existing combined cloud
- Fix mesh texturing: look up images by filepath not name, validate cached materials
- Pack video-extracted images before temp dir cleanup to fix untextured meshes
- Default model/batch/segmentation panels to collapsed